### PR TITLE
Corrigindo ordem de prioridade da expressão.

### DIFF
--- a/Capitulo 4/ex15.c
+++ b/Capitulo 4/ex15.c
@@ -7,25 +7,25 @@ int main(){
     scanf("%f%f%f", &a, &b, &c);
 
     if(a == 0){
-        printf("Nao eh uma equacao de 2º grau!");
+        printf("Nao eh uma equacao de 2º grau!\n");
         return 0;
     }
 
     delta = (b * b) - 4 * a * c;
 
     if(delta < 0){
-        printf("Nao existe raiz!");
+        printf("Nao existe raiz!\n");
         return 0;
     }
     if(delta == 0){
-        x1 = - b / 2 * a;
-        printf("Raiz unica = %f", x1);
+        x1 = - b / (2 * a);
+        printf("Raiz unica = %f\n", x1);
         return 0;
     }
     // o trecho abaixo so executa se todos if's acima nao forem verdadeiros
     x1 = (- b + sqrt(delta)) / (2 * a);
     x2 = (- b - sqrt(delta)) / (2 * a);
     printf("x1 = %f\n", x1);
-    printf("x2 = %f", x2);
+    printf("x2 = %f\n", x2);
     return 0;
 }

--- a/Capitulo 4/ex15.c
+++ b/Capitulo 4/ex15.c
@@ -23,8 +23,8 @@ int main(){
         return 0;
     }
     // o trecho abaixo so executa se todos if's acima nao forem verdadeiros
-    x1 = (- b + sqrt(delta)) / 2 * a;
-    x2 = (- b - sqrt(delta)) / 2 * a;
+    x1 = (- b + sqrt(delta)) / (2 * a);
+    x2 = (- b - sqrt(delta)) / (2 * a);
     printf("x1 = %f\n", x1);
     printf("x2 = %f", x2);
     return 0;


### PR DESCRIPTION
Inicialmente a prioridade da expressão era pegar o valor de -b +- √Δ e dividir por 2 e depois multiplicar por a. Com os parênteses a prioridade muda e o resultado da expressão será divido pelo resultado de 2 * a.